### PR TITLE
Support namespaced exceptions for assert_raise[s]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ of [keepachangelog.com][2].
 
 ### Added
 
-- None
+- [#18](https://github.com/jaredbeck/minitest_to_rspec/pull/18) -
+  Support namespaced exceptions for assert_raise[s]
 
 ### Fixed
 

--- a/lib/minitest_to_rspec/input/model/call.rb
+++ b/lib/minitest_to_rspec/input/model/call.rb
@@ -103,7 +103,7 @@ module MinitestToRspec
         # assertion failure message, which will be discarded later.
         def raise_error_args?
           arg_types = arguments.map(&:sexp_type)
-          [[], [:str], [:const], %i[const str]].include?(arg_types)
+          [[], [:str], [:const], %i[const str], [:colon2]].include?(arg_types)
         end
 
         def receiver

--- a/spec/fixtures/25_raise_namespace/in.rb
+++ b/spec/fixtures/25_raise_namespace/in.rb
@@ -1,0 +1,7 @@
+describe "Kiwi.delicious!" do
+  test "raises Namespace::NotDeliciousError" do
+    assert_raises(Namespace::NotDeliciousError) do
+      Kiwi.delicious!
+    end
+  end
+end

--- a/spec/fixtures/25_raise_namespace/out.rb
+++ b/spec/fixtures/25_raise_namespace/out.rb
@@ -1,0 +1,5 @@
+describe("Kiwi.delicious!") do
+  it("raises Namespace::NotDeliciousError") do
+    expect { Kiwi.delicious! }.to(raise_error(Namespace::NotDeliciousError))
+  end
+end


### PR DESCRIPTION
Currently following code is not supported:

```
describe "Kiwi.delicious!" do
  test "raises Namespace::NotDeliciousError" do
    assert_raises(Namespace::NotDeliciousError) do
      Kiwi.delicious!
    end
  end
end
```

This PR adds support for namespaced exception classes.