### PR TITLE
use latest supported versions of Ruby in Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-  - "2.3.5"
-  - "2.4.2"
+  - "2.3.6"
+  - "2.4.3"
+  - "2.5.0"
 script: bundle exec rake
 sudo: false
 notifications:


### PR DESCRIPTION
As of 2018-03-11, currently supported Ruby versions are:

> https://www.ruby-lang.org/en/downloads/
> Stable releases:
> - Ruby 2.5.0
> - Ruby 2.4.3
> - Ruby 2.3.6
