### PR TITLE
support refute_raise[s]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ of [keepachangelog.com][2].
 
 ### Added
 
-- None
+- [#20](https://github.com/jaredbeck/minitest_to_rspec/pull/20) -
+  Support `refute_raise[s]`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ of [keepachangelog.com][2].
 
 ### Added
 
-- None
+- [#18](https://github.com/jaredbeck/minitest_to_rspec/pull/18) -
+  Support namespaced exceptions for assert_raise[s]
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ assert_not_nil              |       |
 [assert_raises][13]         | 0..2  | Minitest
 refute                      |       |
 refute_equal                |       |
+[refute_raise][39]          |       |
+[refute_raises][39]         |       |
 
 ## Supported Mocha
 
@@ -160,3 +162,4 @@ This project would not be possible without [ruby_parser][14],
 [36]: http://www.rubydoc.info/github/thoughtbot/shoulda-context/master/Shoulda/Context/ClassMethods#context-instance_method
 [37]: http://www.rubydoc.info/github/thoughtbot/shoulda-context/master/Shoulda/Context/Context#setup-instance_method
 [38]: http://www.rubydoc.info/github/thoughtbot/shoulda-context/master/Shoulda/Context/ClassMethods#should-instance_method
+[39]: https://github.com/jaredbeck/minitest_to_rspec/pull/20

--- a/lib/minitest_to_rspec/input/model/call.rb
+++ b/lib/minitest_to_rspec/input/model/call.rb
@@ -36,6 +36,14 @@ module MinitestToRspec
             exp.sexp_type == :call && new(exp).assert_raises?
           end
 
+          def refute_raise?(exp)
+            exp.sexp_type == :call && new(exp).refute_raise?
+          end
+
+          def refute_raises?(exp)
+            exp.sexp_type == :call && new(exp).refute_raises?
+          end
+
           def method_name?(exp, name)
             exp.sexp_type == :call && new(exp).method_name.to_s == name.to_s
           end
@@ -70,6 +78,14 @@ module MinitestToRspec
 
         def assert_raises?
           method_name == :assert_raises && raise_error_args?
+        end
+
+        def refute_raise?
+          method_name == :refute_raise && raise_error_args?
+        end
+
+        def refute_raises?
+          method_name == :refute_raises && raise_error_args?
         end
 
         def calls_in_receiver_chain

--- a/lib/minitest_to_rspec/input/model/call.rb
+++ b/lib/minitest_to_rspec/input/model/call.rb
@@ -103,7 +103,7 @@ module MinitestToRspec
         # assertion failure message, which will be discarded later.
         def raise_error_args?
           arg_types = arguments.map(&:sexp_type)
-          [[], [:str], [:const], %i[const str]].include?(arg_types)
+          [[], [:str], [:const], %i[const str], [:colon2]].include?(arg_types)
         end
 
         def receiver

--- a/lib/minitest_to_rspec/input/model/iter.rb
+++ b/lib/minitest_to_rspec/input/model/iter.rb
@@ -36,6 +36,14 @@ module MinitestToRspec
           !empty? && Model::Call.assert_raises?(@exp[1])
         end
 
+        def refute_raise?
+          !empty? && Model::Call.refute_raise?(@exp[1])
+        end
+
+        def refute_raises?
+          !empty? && Model::Call.refute_raises?(@exp[1])
+        end
+
         def block
           @exp[3]
         end

--- a/lib/minitest_to_rspec/input/subprocessors/iter.rb
+++ b/lib/minitest_to_rspec/input/subprocessors/iter.rb
@@ -72,6 +72,14 @@ module MinitestToRspec
           expect_to(raise_error(*iter.call_arguments), iter.block, false)
         end
 
+        def method_refute_raise(iter)
+          method_refute_raises(iter)
+        end
+
+        def method_refute_raises(iter)
+          expect_to_not(raise_error(*iter.call_arguments), iter.block, false)
+        end
+
         def method_setup(exp)
           replace_method_name(exp, :before)
         end

--- a/spec/fixtures/25_raise_namespace/in.rb
+++ b/spec/fixtures/25_raise_namespace/in.rb
@@ -1,0 +1,7 @@
+describe "Kiwi.delicious!" do
+  test "raises Namespace::NotDeliciousError" do
+    assert_raises(Namespace::NotDeliciousError) do
+      Kiwi.delicious!
+    end
+  end
+end

--- a/spec/fixtures/25_raise_namespace/out.rb
+++ b/spec/fixtures/25_raise_namespace/out.rb
@@ -1,0 +1,5 @@
+describe("Kiwi.delicious!") do
+  it("raises Namespace::NotDeliciousError") do
+    expect { Kiwi.delicious! }.to(raise_error(Namespace::NotDeliciousError))
+  end
+end

--- a/spec/fixtures/26_refute/in.rb
+++ b/spec/fixtures/26_refute/in.rb
@@ -1,0 +1,25 @@
+describe "Banana.delicious!" do
+  test "doesn't raise DeliciousError" do
+    refute_raise(DeliciousError) do
+      Banana.delicious!
+    end
+  end
+
+  test "doesn't raises DeliciousError" do
+    refute_raises(DeliciousError) do
+      Banana.delicious!
+    end
+  end
+
+  test "doesn't raise namespaced DeliciousError" do
+    refute_raise(Namespace::DeliciousError) do
+      Banana.delicious!
+    end
+  end
+
+  test "doesn't raises namespaced DeliciousError" do
+    refute_raises(Namespace::DeliciousError) do
+      Banana.delicious!
+    end
+  end
+end

--- a/spec/fixtures/26_refute/out.rb
+++ b/spec/fixtures/26_refute/out.rb
@@ -1,0 +1,14 @@
+describe("Banana.delicious!") do
+  it("doesn't raise DeliciousError") do
+    expect { Banana.delicious! }.to_not(raise_error(DeliciousError))
+  end
+  it("doesn't raises DeliciousError") do
+    expect { Banana.delicious! }.to_not(raise_error(DeliciousError))
+  end
+  it("doesn't raise namespaced DeliciousError") do
+    expect { Banana.delicious! }.to_not(raise_error(Namespace::DeliciousError))
+  end
+  it("doesn't raises namespaced DeliciousError") do
+    expect { Banana.delicious! }.to_not(raise_error(Namespace::DeliciousError))
+  end
+end


### PR DESCRIPTION
Some code that I'm working on uses `refute_raise[s]`:

```
      refute_raises(RuntimeError) { session.save_changes }
```

This PR adds support for this operation, and converts it to:

```
    expect { session.save_changes }.to_not(raise_error(RuntimeError))
```