### PR TITLE
convert setup/teardown methods to before/after blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ of [keepachangelog.com][2].
 
 ### Added
 
-- None
+- [#21](https://github.com/jaredbeck/minitest_to_rspec/pull/21) -
+  convert `setup`/`teardown` methods to `before`/`after` blocks
 
 ### Fixed
 

--- a/lib/minitest_to_rspec/input/model/defn.rb
+++ b/lib/minitest_to_rspec/input/model/defn.rb
@@ -23,6 +23,14 @@ module MinitestToRspec
         def test_method?
           method_name.start_with?('test_')
         end
+
+        def setup?
+          method_name == 'setup'
+        end
+
+        def teardown?
+          method_name == 'teardown'
+        end
       end
     end
   end

--- a/lib/minitest_to_rspec/input/subprocessors/defn.rb
+++ b/lib/minitest_to_rspec/input/subprocessors/defn.rb
@@ -24,6 +24,18 @@ module MinitestToRspec
               s(:call, nil, :it, s(:str, example_title)),
               0,
               example_block)
+          elsif @exp.setup?
+            s(:iter,
+              s(:call, nil, :before),
+              0,
+              example_block
+            )
+          elsif @exp.teardown?
+            s(:iter,
+              s(:call, nil, :after),
+              0,
+              example_block
+            )
           else
             @original
           end

--- a/spec/fixtures/27_setup_as_method/in.rb
+++ b/spec/fixtures/27_setup_as_method/in.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class BananaTest < ActiveSupport::TestCase
+  include Monkeys
+
+  def setup
+    fend_off_the_monkeys
+  end
+
+  test "is delicious" do
+    assert Banana.new.delicious?
+  end
+
+  def teardown
+    appologize_to_the_monkeys
+  end
+end

--- a/spec/fixtures/27_setup_as_method/out.rb
+++ b/spec/fixtures/27_setup_as_method/out.rb
@@ -1,0 +1,7 @@
+require("spec_helper")
+RSpec.describe(Banana) do
+  include(Monkeys)
+  before { fend_off_the_monkeys }
+  it("is delicious") { expect(Banana.new.delicious?).to(eq(true)) }
+  after { appologize_to_the_monkeys }
+end


### PR DESCRIPTION
Allows to convert code written in this format:

```
require 'test_helper'

class BananaTest < ActiveSupport::TestCase
  include Monkeys

  def setup
    fend_off_the_monkeys
  end

  test "is delicious" do
    assert Banana.new.delicious?
  end

  def teardown
    appologize_to_the_monkeys
  end
end
```