### PR TITLE
Try to preserve newlines (--newline option)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ of [keepachangelog.com][2].
 
 ### Added
 
-- None
+- [#22](https://github.com/jaredbeck/minitest_to_rspec/pull/22) -
+  add `--newline` option to preserve newline
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ gem install minitest_to_rspec
 ### CLI
 
 ```bash
-mt2rspec [--rails] [--mocha] source_file [target_file]
+mt2rspec [--rails] [--mocha] [--newline] source_file [target_file]
 mt2rspec --help
 ```
 

--- a/lib/minitest_to_rspec/cli.rb
+++ b/lib/minitest_to_rspec/cli.rb
@@ -14,7 +14,7 @@ module MinitestToRspec
     E_CANNOT_CREATE_TARGET_DIR = 5
 
     BANNER = <<~EOS
-      Usage: mt2rspec [--rails] [--mocha] source_file [target_file]
+      Usage: mt2rspec [--rails] [--mocha] [--newline] source_file [target_file]
 
       Reads source_file, writes target_file. If target_file is omitted,
       its location will be inferred. For example, test/fruit/banana_test.rb
@@ -28,19 +28,16 @@ module MinitestToRspec
       Requires rails_helper instead of spec_helper.
       Passes :type metadatum to RSpec.describe.
     EOS
+    OPT_NEWLINE = 'Try to preserve newlines.'
 
     attr_reader :source, :target
 
     def initialize(args)
-      opts = Trollop.options(args) do
-        version MinitestToRspec::VERSION
-        banner BANNER
-        opt :rails, OPT_RAILS, short: :none
-        opt :mocha, OPT_MOCHA, short: :none
-      end
+      opts = parse_opts(args)
 
       @rails = opts[:rails]
       @mocha = opts[:mocha]
+      @newline = opts[:newline]
       case args.length
       when 2
         @source, @target = args
@@ -50,6 +47,16 @@ module MinitestToRspec
       else
         warn 'Please specify source file'
         exit E_USAGE
+      end
+    end
+
+    def parse_opts(args)
+      Trollop.options(args) do
+        version MinitestToRspec::VERSION
+        banner BANNER
+        opt :rails, OPT_RAILS, short: :none
+        opt :mocha, OPT_MOCHA, short: :none
+        opt :newline, OPT_NEWLINE, short: :none
       end
     end
 
@@ -80,7 +87,7 @@ module MinitestToRspec
     end
 
     def converter
-      Converter.new(mocha: @mocha, rails: @rails)
+      Converter.new(mocha: @mocha, rails: @rails, newline: @newline)
     end
 
     def ensure_target_directory(target)

--- a/lib/minitest_to_rspec/converter.rb
+++ b/lib/minitest_to_rspec/converter.rb
@@ -8,15 +8,21 @@ require_relative 'errors'
 module MinitestToRspec
   # Converts strings of minitest code. Does not read or write files.
   class Converter
-    def initialize(rails: false, mocha: false)
+    NEWLINE = '__NEWLINE__'
+
+    def initialize(rails: false, mocha: false, newline: false)
       @processor = Input::Processor.new(rails, mocha)
+      @newline = newline
     end
 
     # - `input` - Contents of a ruby file.
     # - `file_path` - Optional. Value will replace any `__FILE__`
     #   keywords in the input.
     def convert(input, file_path = nil)
-      render process parse(input, file_path)
+      input = input.gsub("\n\n", "\n#{NEWLINE}\n") if @newline
+      output = render process parse(input, file_path)
+      output = output.gsub(NEWLINE, '') if @newline
+      output
     end
 
     private

--- a/spec/fixtures/28_newline/in.rb
+++ b/spec/fixtures/28_newline/in.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class BananaTest < ActiveSupport::TestCase
+  include Monkeys
+
+  def setup
+    fend_off_the_monkeys
+  end
+
+  test "is very delicious" do
+    Banana.deliciousness *= 100
+
+    assert Banana.new.delicious?    
+  end
+
+  def teardown
+    appologize_to_the_monkeys
+  end
+end

--- a/spec/fixtures/28_newline/out.rb
+++ b/spec/fixtures/28_newline/out.rb
@@ -1,0 +1,15 @@
+require("spec_helper")
+
+RSpec.describe(Banana) do
+  include(Monkeys)
+  
+  before { fend_off_the_monkeys }
+  
+  it("is very delicious") do
+    Banana.deliciousness *= 100
+    
+    expect(Banana.new.delicious?).to(eq(true))
+  end
+  
+  after { appologize_to_the_monkeys }
+end


### PR DESCRIPTION
Converts

```
require 'test_helper'

class BananaTest < ActiveSupport::TestCase
  include Monkeys

  def setup
    fend_off_the_monkeys
  end

  test "is very delicious" do
    Banana.deliciousness *= 100

    assert Banana.new.delicious?    
  end

  def teardown
    appologize_to_the_monkeys
  end
end
```

to

```
require("spec_helper")

RSpec.describe(Banana) do
  include(Monkeys)
  
  before { fend_off_the_monkeys }
  
  it("is very delicious") do
    Banana.deliciousness *= 100
    
    expect(Banana.new.delicious?).to(eq(true))
  end
  
  after { appologize_to_the_monkeys }
end
```