### PR TITLE
Support Test::Unit::TestCase and more assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ of [keepachangelog.com][2].
 
 ### Added
 
-- None
+- [#23](https://github.com/jaredbeck/minitest_to_rspec/pull/23)
+  - support `Test::Unit::TestCase`
+  - support `assert_empty`
+  - support `assert_kind_of`
+  - support `assert_instance_of`
 
 ### Fixed
 

--- a/lib/minitest_to_rspec/input/subprocessors/call.rb
+++ b/lib/minitest_to_rspec/input/subprocessors/call.rb
@@ -55,8 +55,20 @@ module MinitestToRspec
           matcher(:be_nil)
         end
 
+        def be_empty
+          matcher(:be_empty)
+        end
+
         def be_truthy
           matcher(:be_truthy)
+        end
+
+        def be_a(exp)
+          matcher(:be_a, exp)
+        end
+
+        def be_instance_of(exp)
+          matcher(:be_instance_of, exp)
         end
 
         def call_to_question_mark?(exp)
@@ -95,10 +107,26 @@ module MinitestToRspec
           expect_to_not(be_nil, @exp.arguments[0], true)
         end
 
+        def method_assert_empty
+          expect_to(be_empty, @exp.arguments[0], true)
+        end
+
         def method_assert_not_equal
           expected = @exp.arguments[0]
           calculated = @exp.arguments[1]
           expect_to_not(eq(expected), calculated, true)
+        end
+
+        def method_assert_kind_of
+          expected = @exp.arguments[0]
+          calculated = @exp.arguments[1]
+          expect_to(be_a(expected), calculated, true)
+        end
+
+        def method_assert_instance_of
+          expected = @exp.arguments[0]
+          calculated = @exp.arguments[1]
+          expect_to(be_instance_of(expected), calculated, true)
         end
 
         def method_expects

--- a/spec/fixtures/28_test_unit_test_case/in.rb
+++ b/spec/fixtures/28_test_unit_test_case/in.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BananaTest < Test::Unit::TestCase
+  def test_delicious
+    assert Banana.new.delicious?
+  end
+end

--- a/spec/fixtures/28_test_unit_test_case/out.rb
+++ b/spec/fixtures/28_test_unit_test_case/out.rb
@@ -1,0 +1,4 @@
+require("spec_helper")
+RSpec.describe(Banana) do
+  it("delicious") { expect(Banana.new.delicious?).to(eq(true)) }
+end

--- a/spec/fixtures/29_assert_empty/in.rb
+++ b/spec/fixtures/29_assert_empty/in.rb
@@ -1,0 +1,2 @@
+assert_empty(Banana.new)
+assert_empty(Banana.new, "Expected empty banana skin but got delicious content")

--- a/spec/fixtures/29_assert_empty/out.rb
+++ b/spec/fixtures/29_assert_empty/out.rb
@@ -1,0 +1,2 @@
+expect(Banana.new).to(be_empty)
+expect(Banana.new).to(be_empty)

--- a/spec/fixtures/30_assert_kind_of/in.rb
+++ b/spec/fixtures/30_assert_kind_of/in.rb
@@ -1,0 +1,2 @@
+assert_kind_of(Banana, Banana.new)
+assert_kind_of(Banana, Banana.new, "Expected Banana to be a kind of Banana")

--- a/spec/fixtures/30_assert_kind_of/out.rb
+++ b/spec/fixtures/30_assert_kind_of/out.rb
@@ -1,0 +1,2 @@
+expect(Banana.new).to(be_a(Banana))
+expect(Banana.new).to(be_a(Banana))

--- a/spec/fixtures/31_assert_instance_of/in.rb
+++ b/spec/fixtures/31_assert_instance_of/in.rb
@@ -1,0 +1,2 @@
+assert_instance_of(Banana, Banana.new)
+assert_instance_of(Banana, Banana.new, "Expected Banana to be an actual Banana")

--- a/spec/fixtures/31_assert_instance_of/out.rb
+++ b/spec/fixtures/31_assert_instance_of/out.rb
@@ -1,0 +1,2 @@
+expect(Banana.new).to(be_instance_of(Banana))
+expect(Banana.new).to(be_instance_of(Banana))

--- a/spec/lib/input/subprocessors/klass_spec.rb
+++ b/spec/lib/input/subprocessors/klass_spec.rb
@@ -84,6 +84,13 @@ module MinitestToRspec
             ))
           end
 
+          it 'converts a Test::Unit::TestCase' do
+            input = parse('class BananaTest < Test::Unit::TestCase; end')
+            expect(process(input, true)).to eq(parse(
+              'RSpec.describe(Banana, type: :model) do; end'
+            ))
+          end
+
           it 'converts a Draper::TestCase' do
             input = parse('class BananaDecoratorTest < Draper::TestCase; end')
             expect(process(input, true)).to eq(parse(


### PR DESCRIPTION
To get `Test::Unit::TestCase` to work I mainly had to change `#ancestor_names` a bit. It couldn't handle module names with more than two parts before.