### PR TITLE
Replace deprecated trollop with its replacement: optimist gem; update out-of-date gems; update travis ruby branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /spec/reports/
 /tmp/
 .idea/
+gemsurance_report.html

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Layout/EndOfLine:
+  EnforcedStyle: native
+
 Layout/IndentFirstArgument:
   EnforcedStyle: consistent
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   Exclude:
     - spec/fixtures/**/*
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - spec/fixtures/**/*
+    - tmp/**/*
   TargetRubyVersion: 2.4
 
 Layout/AlignParameters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   EnforcedStyle: consistent
 
 Layout/IndentHeredoc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - "2.3.6"
-  - "2.4.3"
-  - "2.5.0"
+  - "2.4.9"
+  - "2.6.5"
+  - "2.5.7"
 script: bundle exec rake
 sudo: false
 notifications:

--- a/lib/minitest_to_rspec/cli.rb
+++ b/lib/minitest_to_rspec/cli.rb
@@ -80,6 +80,7 @@ module MinitestToRspec
     def ensure_target_directory(target)
       dir = File.dirname(target)
       return if Dir.exist?(dir)
+
       begin
         FileUtils.mkdir_p(dir)
       rescue SystemCallError => e

--- a/lib/minitest_to_rspec/cli.rb
+++ b/lib/minitest_to_rspec/cli.rb
@@ -2,7 +2,7 @@
 
 require 'fileutils'
 require 'minitest_to_rspec'
-require 'trollop'
+require 'optimist'
 
 module MinitestToRspec
   # Command-Line Interface (CLI) instantiated by `bin/mt2rspec`
@@ -97,7 +97,7 @@ module MinitestToRspec
     end
 
     def parse_args(args)
-      Trollop.options(args) do
+      Optimist.options(args) do
         version MinitestToRspec.gem_version.to_s
         banner BANNER
         opt :rails, OPT_RAILS, short: :none

--- a/lib/minitest_to_rspec/input/model/call.rb
+++ b/lib/minitest_to_rspec/input/model/call.rb
@@ -59,6 +59,7 @@ module MinitestToRspec
 
         def assert_difference?
           return false unless method_name == :assert_difference
+
           [[:str], %i[str lit]].include?(argument_types)
         end
 
@@ -91,6 +92,7 @@ module MinitestToRspec
         def calls_in_receiver_chain
           receiver_chain.each_with_object([]) do |e, a|
             next unless sexp_type?(:call, e)
+
             a << self.class.new(e)
           end
         end

--- a/lib/minitest_to_rspec/input/model/klass.rb
+++ b/lib/minitest_to_rspec/input/model/klass.rb
@@ -42,7 +42,7 @@ module MinitestToRspec
         end
 
         def block
-          @_block ||= @exp[3..-1] || []
+          @block ||= @exp[3..-1] || []
         end
 
         def test_unit_test_case?
@@ -72,7 +72,7 @@ module MinitestToRspec
         # - Inherit Bar::Foo #=> s(:colon2, s(:const, :Bar), :Foo)
         #
         def parent
-          @_parent ||= @exp[2]
+          @parent ||= @exp[2]
         end
 
         # Returns true if `@exp` inherits from, e.g. ActiveSupport::TestCase.

--- a/lib/minitest_to_rspec/input/model/klass.rb
+++ b/lib/minitest_to_rspec/input/model/klass.rb
@@ -79,6 +79,7 @@ module MinitestToRspec
         # TODO: Other test case parent classes.
         def test_case?
           return false unless sexp_type?(:colon2, parent)
+
           active_support_test_case? ||
             action_controller_test_case? ||
             action_mailer_test_case? ||

--- a/lib/minitest_to_rspec/input/subprocessors/base.rb
+++ b/lib/minitest_to_rspec/input/subprocessors/base.rb
@@ -63,7 +63,7 @@ module MinitestToRspec
             s(:call, nil, :expect),
             0,
             full_process(block)
-          )
+           )
         end
 
         # If it's a `Sexp`, run `obj` through a new `Processor`.  Otherwise,

--- a/lib/minitest_to_rspec/input/subprocessors/call.rb
+++ b/lib/minitest_to_rspec/input/subprocessors/call.rb
@@ -181,6 +181,7 @@ module MinitestToRspec
         # - (name, stubs)
         def method_stub
           raise ArgumentError unless @exp.is_a?(Model::Call)
+
           if @exp.receiver.nil?
             s(:call, nil, :double, *@exp.arguments)
           else
@@ -273,10 +274,10 @@ module MinitestToRspec
               s(:block,
                 s(:str, 'Sorry for the pointless lambda here.'),
                 *array_of_calls
-              )
-            ),
+               )
+             ),
             :call
-          )
+           )
         end
 
         # `refsert` - Code shared by refute and assert. I could also have gone

--- a/lib/minitest_to_rspec/input/subprocessors/defn.rb
+++ b/lib/minitest_to_rspec/input/subprocessors/defn.rb
@@ -29,13 +29,13 @@ module MinitestToRspec
               s(:call, nil, :before),
               0,
               example_block
-            )
+             )
           elsif @exp.teardown?
             s(:iter,
               s(:call, nil, :after),
               0,
               example_block
-            )
+             )
           else
             @original
           end

--- a/lib/minitest_to_rspec/input/subprocessors/iter.rb
+++ b/lib/minitest_to_rspec/input/subprocessors/iter.rb
@@ -32,7 +32,7 @@ module MinitestToRspec
             change(diff_exp),
             :by,
             by_exp
-          )
+           )
         end
 
         def matcher_with_block(matcher_name, block)
@@ -40,7 +40,7 @@ module MinitestToRspec
             s(:call, nil, matcher_name),
             0,
             block
-          )
+           )
         end
 
         def method_assert_difference(exp)

--- a/minitest_to_rspec.gemspec
+++ b/minitest_to_rspec.gemspec
@@ -29,8 +29,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
 
   spec.add_development_dependency 'bundler', '~> 1.17.3'
-  spec.add_development_dependency 'byebug', '~> 9.1'
-  spec.add_development_dependency 'rake', '~> 12.1'
+  spec.add_development_dependency 'byebug', '~> 11.0.1'
+  spec.add_development_dependency 'rake', '~> 13.0.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'rubocop', '~> 0.51.0'
+  spec.add_development_dependency 'rubocop', '~> 0.76.0'
+  spec.add_development_dependency 'gemsurance', '~> 0.10.0'
 end

--- a/minitest_to_rspec.gemspec
+++ b/minitest_to_rspec.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.7'
+  spec.required_ruby_version = '>= 2.4.9'
 
   spec.add_runtime_dependency 'optimist', '~> 3.0.0'
   spec.add_runtime_dependency 'ruby2ruby', '~> 2.3'

--- a/minitest_to_rspec.gemspec
+++ b/minitest_to_rspec.gemspec
@@ -22,13 +22,13 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.7'
 
   spec.add_runtime_dependency 'optimist', '~> 3.0.0'
   spec.add_runtime_dependency 'ruby2ruby', '~> 2.3'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler', '~> 2.0.2'
   spec.add_development_dependency 'byebug', '~> 9.1'
   spec.add_development_dependency 'rake', '~> 12.1'
   spec.add_development_dependency 'rspec', '~> 3.5'

--- a/minitest_to_rspec.gemspec
+++ b/minitest_to_rspec.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'byebug', '~> 11.0.1'
+  spec.add_development_dependency 'gemsurance', '~> 0.10.0'
   spec.add_development_dependency 'rake', '~> 13.0.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'rubocop', '~> 0.76.0'
-  spec.add_development_dependency 'gemsurance', '~> 0.10.0'
 end

--- a/minitest_to_rspec.gemspec
+++ b/minitest_to_rspec.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'minitest_to_rspec/version'
 
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3.0'
 
+  spec.add_runtime_dependency 'optimist', '~> 3.0.0'
   spec.add_runtime_dependency 'ruby2ruby', '~> 2.3'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
-  spec.add_runtime_dependency 'trollop', '~> 2.1'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'byebug', '~> 9.1'

--- a/minitest_to_rspec.gemspec
+++ b/minitest_to_rspec.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'ruby2ruby', '~> 2.3'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.8'
 
-  spec.add_development_dependency 'bundler', '~> 2.0.2'
+  spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'byebug', '~> 9.1'
   spec.add_development_dependency 'rake', '~> 12.1'
   spec.add_development_dependency 'rspec', '~> 3.5'

--- a/spec/lib/input/subprocessors/base_spec.rb
+++ b/spec/lib/input/subprocessors/base_spec.rb
@@ -19,7 +19,7 @@ module MinitestToRspec
                 s(:call, nil, :allow, msg_recipient),
                 :to,
                 matcher
-              )
+               )
             )
           end
         end

--- a/spec/lib/input/subprocessors/call_spec.rb
+++ b/spec/lib/input/subprocessors/call_spec.rb
@@ -108,8 +108,8 @@ module MinitestToRspec
                   s(:str, 'yellow'),
                   s(:lit, :delicious),
                   s(:true)
-                )
-              )
+                 )
+               )
             }
             expect(process(input.call)).to eq(input.call)
           end

--- a/spec/lib/input/subprocessors/klass_spec.rb
+++ b/spec/lib/input/subprocessors/klass_spec.rb
@@ -40,9 +40,9 @@ module MinitestToRspec
             context 'emtpy' do
               it 'converts' do
                 input = s(:class,
-                  :BananaTest,
-                  s(:colon2, s(:const, :ActiveSupport), :TestCase)
-                )
+                          :BananaTest,
+                          s(:colon2, s(:const, :ActiveSupport), :TestCase)
+                         )
                 iter = process(input)
                 expect(iter.sexp_type).to eq(:iter)
                 expect(iter.length).to eq(3) # type, call, args
@@ -54,14 +54,14 @@ module MinitestToRspec
             context 'not empty' do
               it 'converts' do
                 inp = s(:class,
-                  :BananaTest,
-                  s(:colon2, s(:const, :ActiveSupport), :TestCase),
-                  s(:iter,
-                    s(:call, nil, :test, s(:str, 'is delicious')),
-                    0,
-                    s(:call, nil, :puts)
-                  )
-                )
+                        :BananaTest,
+                        s(:colon2, s(:const, :ActiveSupport), :TestCase),
+                        s(:iter,
+                          s(:call, nil, :test, s(:str, 'is delicious')),
+                          0,
+                          s(:call, nil, :puts)
+                         )
+                       )
                 expect(process(inp)).to eq(parse(
                   <<-EOS
                     RSpec.describe(Banana) do
@@ -131,9 +131,10 @@ module MinitestToRspec
                   s(:class,
                     s(:colon2, s(:const, :Fruit), :BananaTest),
                     nil
-                  )
+                   )
                 )
-              }.to raise_error(ModuleShorthandError,
+              }.to raise_error(
+                ModuleShorthandError,
                 /Please convert your class definition to use nested modules/
               )
             end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'minitest_to_rspec'
 require 'byebug'


### PR DESCRIPTION
Our app relies on minitest_to_rspec.  Recently we did a completely fresh install and got the following message from bundler:

> Post-install message from trollop:
> !    The 'trollop' gem has been deprecated and has been replaced by 'optimist'.
> !    See: https://rubygems.org/gems/optimist
> !    And: https://github.com/ManageIQ/optimist
