### PR TITLE
Switched the deprecated Trollop gem for Optimist

### DIFF
--- a/lib/minitest_to_rspec/cli.rb
+++ b/lib/minitest_to_rspec/cli.rb
@@ -2,7 +2,7 @@
 
 require 'fileutils'
 require 'minitest_to_rspec'
-require 'trollop'
+require 'optimist'
 
 module MinitestToRspec
   # Command-Line Interface (CLI) instantiated by `bin/mt2rspec`
@@ -96,7 +96,7 @@ module MinitestToRspec
     end
 
     def parse_args(args)
-      Trollop.options(args) do
+      Optimist.options(args) do
         version MinitestToRspec.gem_version.to_s
         banner BANNER
         opt :rails, OPT_RAILS, short: :none

--- a/minitest_to_rspec.gemspec
+++ b/minitest_to_rspec.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3.0'
 
+  spec.add_runtime_dependency 'optimist', '~> 3.0'
   spec.add_runtime_dependency 'ruby2ruby', '~> 2.4.4'
   spec.add_runtime_dependency 'ruby_parser', '~> 3.11.0'
-  spec.add_runtime_dependency 'trollop', '~> 2.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'byebug', '~> 11.0'


### PR DESCRIPTION
I know that there is [another PR](https://github.com/jaredbeck/minitest_to_rspec/pull/28) open for this but there was a lot going on in there. So here is a PR that just switches Trollop to Optimist.