### PR TITLE
Updated Rubocop version and updated obsolete config settings (#1)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,13 +5,13 @@ AllCops:
     - spec/fixtures/**/*
   TargetRubyVersion: 2.3
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   EnforcedStyle: consistent
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   EnforcedStyle: squiggly
 
 Layout/MultilineMethodCallBraceLayout:
@@ -53,7 +53,7 @@ Style/BlockDelimiters:
 
 Style/Documentation:
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 
 # Too subtle to lint. Avoid postfix operators unless line is very simple.
 Style/IfUnlessModifier:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,41 +10,41 @@
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.
 # SupportedStyles: with_first_argument, with_fixed_indentation
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Exclude:
-    - 'spec/lib/input/subprocessors/klass_spec.rb'
+    - "spec/lib/input/subprocessors/klass_spec.rb"
 
 # Offense count: 13
 # Cop supports --auto-correct.
 Layout/ClosingParenthesisIndentation:
   Exclude:
-    - 'lib/minitest_to_rspec/input/subprocessors/base.rb'
-    - 'lib/minitest_to_rspec/input/subprocessors/call.rb'
-    - 'lib/minitest_to_rspec/input/subprocessors/defn.rb'
-    - 'lib/minitest_to_rspec/input/subprocessors/iter.rb'
-    - 'spec/lib/input/subprocessors/base_spec.rb'
-    - 'spec/lib/input/subprocessors/call_spec.rb'
-    - 'spec/lib/input/subprocessors/klass_spec.rb'
+    - "lib/minitest_to_rspec/input/subprocessors/base.rb"
+    - "lib/minitest_to_rspec/input/subprocessors/call.rb"
+    - "lib/minitest_to_rspec/input/subprocessors/defn.rb"
+    - "lib/minitest_to_rspec/input/subprocessors/iter.rb"
+    - "spec/lib/input/subprocessors/base_spec.rb"
+    - "spec/lib/input/subprocessors/call_spec.rb"
+    - "spec/lib/input/subprocessors/klass_spec.rb"
 
 # Offense count: 5
 # Cop supports --auto-correct.
 Layout/EmptyLineAfterGuardClause:
   Exclude:
-    - 'lib/minitest_to_rspec/cli.rb'
-    - 'lib/minitest_to_rspec/input/model/call.rb'
-    - 'lib/minitest_to_rspec/input/model/klass.rb'
-    - 'lib/minitest_to_rspec/input/subprocessors/call.rb'
+    - "lib/minitest_to_rspec/cli.rb"
+    - "lib/minitest_to_rspec/input/model/call.rb"
+    - "lib/minitest_to_rspec/input/model/klass.rb"
+    - "lib/minitest_to_rspec/input/subprocessors/call.rb"
 
 # Offense count: 2
 # Configuration parameters: EnforcedStyleForLeadingUnderscores.
 # SupportedStylesForLeadingUnderscores: disallowed, required, optional
 Naming/MemoizedInstanceVariableName:
   Exclude:
-    - 'lib/minitest_to_rspec/input/model/klass.rb'
+    - "lib/minitest_to_rspec/input/model/klass.rb"
 
 # Offense count: 2
 # Cop supports --auto-correct.
 Style/ExpandPathArguments:
   Exclude:
-    - 'minitest_to_rspec.gemspec'
-    - 'spec/spec_helper.rb'
+    - "minitest_to_rspec.gemspec"
+    - "spec/spec_helper.rb"

--- a/minitest_to_rspec.gemspec
+++ b/minitest_to_rspec.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'byebug', '~> 11.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
-  spec.add_development_dependency 'rubocop', '~> 0.76.0'
+  spec.add_development_dependency 'rubocop', '~> 0.79'
 end


### PR DESCRIPTION
Bumped the Rubocop gem to the latest version and updated some of the `Layout/*` rules that have now changed names.

One side effect of editing the `.yml` files in VSCode (and whatever setting/plugin I have running) is that it has updated the quotes from single to double quotes. If this is a problem let me know and I'll try and do another PR with them unchanged.